### PR TITLE
Fix loading shared.sh

### DIFF
--- a/find_within_files.sh
+++ b/find_within_files.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -uo pipefail  # No -e to support write to canary file after cancel
+BASE_DIR="$(dirname "$(realpath "$0")")"
 
-. shared.sh
+. $BASE_DIR/shared.sh
 
 IFS=: read -r -a GLOB_PATTERNS <<< "$GLOBS"
 GLOBS=()


### PR DESCRIPTION
When cwd is not the extension dir, importing `shared.sh` fails. This causes the `array_join` function to be undefined, and bad behavior when having multiple folders in the same workspace. See https://github.com/tomrijndorp/vscode-finditfaster/issues/12