### PR TITLE
An attempt at windows support

### DIFF
--- a/find_files.ps1
+++ b/find_files.ps1
@@ -5,8 +5,8 @@ trap
 {
     # If we except, lets report it visually. Can help with debugging if there IS a problem
     # in here.
-    Write-Host "EXCEPTION: $PSItem.ToString()" -ForegroundColor Red
-    Write-Host "$PSItem.ScriptStackTrace"
+    Write-Host "EXCEPTION: $($PSItem.ToString())" -ForegroundColor Red
+    Write-Host "$($PSItem.ScriptStackTrace)"
     Start-Sleep 10
 }
 
@@ -55,13 +55,8 @@ if ($PATHS.Count -eq 1) {
         exit 1
     }
     Push-Location "$SINGLE_DIR_ROOT"
-    $PATHS="."
+    $PATHS=""
 }
-
-if ($TYPE_FILTER_ARR.Count -gt 0) {
-    $RG_PREFIX+="$TYPE_FILTER_ARR"
-}
-#RG_PREFIX+=(" 2> /dev/null")
 
 $PREVIEW_ENABLED=VGet "env:FIND_WITHIN_FILES_PREVIEW_ENABLED" 0
 $PREVIEW_COMMAND=VGet "env:FIND_WITHIN_FILES_PREVIEW_COMMAND"  'bat --decorations=always --color=always --plain {}'
@@ -77,9 +72,9 @@ if ("$QUERY".Length -gt 0) {
 }
 
 if($PREVIEW_ENABLED -eq 1) {
-    $result = rg --files --hidden "$USE_GITIGNORE_OPT" --glob '!**/.git/' "$GLOBS" "$TYPE_FILTER_ARR" "$PATHS" | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"  --preview "$PREVIEW_COMMAND" --preview-window "$PREVIEW_WINDOW"
+    $result = Invoke-Expression "rg --files --hidden $USE_GITIGNORE_OPT --glob '!**/.git/' $GLOBS $TYPE_FILTER_ARR $PATHS" | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"  --preview "$PREVIEW_COMMAND" --preview-window "$PREVIEW_WINDOW"
 } else {
-    $result = rg --files --hidden "$USE_GITIGNORE_OPT" --glob '!**/.git/' "$GLOBS" "$TYPE_FILTER_ARR" "$PATHS" | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"
+    $result = Invoke-Expression "rg --files --hidden $USE_GITIGNORE_OPT --glob '!**/.git/' $GLOBS $TYPE_FILTER_ARR $PATHS" | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"
 }
 # Output is filename, line number, character, contents
 if ("$result".Length -lt 1) {

--- a/find_files.ps1
+++ b/find_files.ps1
@@ -30,7 +30,7 @@ function VOptGet($varname,$opt) {
         foreach ($ENTRY in $DATA) {
             if ("$ENTRY".Length -gt 0) {
                 $ARR+=" $opt "
-                $ARR+="`"$ENTRY`""
+                $ARR+="'$ENTRY'"
             }
         }
     }
@@ -55,7 +55,7 @@ if ($PATHS.Count -eq 1) {
         exit 1
     }
     Push-Location "$SINGLE_DIR_ROOT"
-    $PATHS=""
+    $PATHS="."
 }
 
 if ($TYPE_FILTER_ARR.Count -gt 0) {
@@ -77,9 +77,9 @@ if ("$QUERY".Length -gt 0) {
 }
 
 if($PREVIEW_ENABLED -eq 1) {
-    $result = rg --files --hidden "$USE_GITIGNORE_OPT" --glob '!**/.git/' "$GLOBS" "$TYPE_FILTER_ARR" "$PATHS" 2> nul | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"  --preview "$PREVIEW_COMMAND" --preview-window "$PREVIEW_WINDOW"
+    $result = rg --files --hidden "$USE_GITIGNORE_OPT" --glob '!**/.git/' "$GLOBS" "$TYPE_FILTER_ARR" "$PATHS" | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"  --preview "$PREVIEW_COMMAND" --preview-window "$PREVIEW_WINDOW"
 } else {
-    $result = rg --files --hidden "$USE_GITIGNORE_OPT" --glob '!**/.git/' "$GLOBS" "$TYPE_FILTER_ARR" "$PATHS" 2> nul | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"
+    $result = rg --files --hidden "$USE_GITIGNORE_OPT" --glob '!**/.git/' "$GLOBS" "$TYPE_FILTER_ARR" "$PATHS" | fzf --cycle --multi "$QUERYPARAM" "${QUERY}"
 }
 # Output is filename, line number, character, contents
 if ("$result".Length -lt 1) {

--- a/find_within_files.ps1
+++ b/find_within_files.ps1
@@ -1,0 +1,119 @@
+
+
+trap
+{
+    Write-Host "EXCEPTION: $PSItem.ToString()" -ForegroundColor Red
+    Write-Host "$PSItem.ScriptStackTrace"
+    Start-Sleep 10
+}
+
+function VGet($varname, $default) {
+    if (Test-Path "$varname") {
+        $val = (Get-Item $varname).Value
+        if ("$val".Length -gt 0) {
+            return $val
+        }
+    } 
+    return $default
+}
+function VOptGet($varname,$opt) {
+    $ARR=@()
+    $DATA=(VGet "$varname" "")
+    if ("$DATA".Length -gt 0) {
+        $DATA = $DATA.Split(":")
+        foreach ($ENTRY in $DATA) {
+            if ("$ENTRY".Length -gt 0) {
+                $ARR+=" $opt "
+                $ARR+="`"$ENTRY`""
+            }
+        }
+    }
+    return $ARR
+}
+
+Write-Host "A"
+$USE_GITIGNORE_OPT=""
+if ( (VGet "env:USE_GITIGNORE" 0) -eq 0) {
+    $USE_GITIGNORE_OPT="--no-ignore"
+}
+
+Write-Host "B"
+$TYPE_FILTER_ARR=VOptGet "env:TYPE_FILTER" "--type"
+$GLOBS=VOptGet "env:GLOBS" "--glob"
+
+Write-Host "C"
+# If we only have one directory to search, invoke commands relative to that directory
+$PATHS=$args
+$SINGLE_DIR_ROOT=""
+if ($PATHS.Count -eq 1) {
+    $SINGLE_DIR_ROOT=$PATHS[0]
+    if ( -not (Test-Path "$SINGLE_DIR_ROOT")) {
+        Write-Host "Failed to push into: $SINGLE_DIR_ROOT" -ForegroundColor Red
+        exit 1
+    }
+    Push-Location "$SINGLE_DIR_ROOT"
+    $PATHS=""
+}
+
+Write-Host "C"
+# 1. Search for text in files using Ripgrep
+# 2. Interactively restart Ripgrep with reload action
+# 3. Open the file
+$RG_PREFIX="rg "`
+    + "--column "`
+    + "--hidden "`
+    + "$USE_GITIGNORE_OPT "`
+    + "--line-number "`
+    + "--no-heading "`
+    + "--color=always "`
+    + "--smart-case "`
+    + "--colors `"match:fg:green`" "`
+    + "--colors `"path:fg:white`" "`
+    + "--colors `"path:style:nobold`" "`
+    + "--glob `"!**/.git/`" "`
+    + "$GLOBS"
+
+if ($TYPE_FILTER_ARR.Count -gt 0) {
+    $RG_PREFIX+="$TYPE_FILTER_ARR"
+}
+#RG_PREFIX+=(" 2> /dev/null")
+$PREVIEW_ENABLED=VGet "env:FIND_WITHIN_FILES_PREVIEW_ENABLED" 0
+$PREVIEW_COMMAND=VGet "env:FIND_WITHIN_FILES_PREVIEW_COMMAND"  'bat --decorations=always --color=always {1} --highlight-line {2} --style=header,grid'
+$PREVIEW_WINDOW=VGet "env:FIND_WITHIN_FILES_PREVIEW_WINDOW_CONFIG" 'right:border-left:50%:+{2}+3/3:~3'
+$HAS_SELECTION=VGet "env:HAS_SELECTION" 0
+# We match against the beginning of the line so everything matches but nothing gets highlighted...
+$QUERY="`"^`""
+$INITIAL_QUERY=""  # Don't show initial "^" regex in fzf
+if ($HAS_SELECTION -eq 1) {
+    # ... or against the selection if we have one
+    $QUERY=Get-Content "$SELECTION_FILE" -Raw
+    $INITIAL_QUERY="$QUERY" # Do show the initial query when it's not "^"
+}
+
+$FZF_CMD="$RG_PREFIX $QUERY $PATHS"
+Write-Host "$FZF_CMD"
+$Env:FZF_DEFAULT_COMMAND="$FZF_CMD"
+
+$QUERYPARAM=""
+if ("$INITIAL_QUERY".Length -gt 0) {
+    $QUERYPARAM="--query"
+}
+if($PREVIEW_ENABLED -eq 1) {
+    Write-Host "PREVIEW"
+    # $ErrorActionPreference="SilentlyContinue";
+    $result=fzf --delimiter ":" --phony "$QUERYPARAM" "$INITIAL_QUERY" --ansi --cycle --bind "change:reload:powershell -m Start-Sleep .1;`$ErrorActionPreference='SilentlyContinue';$RG_PREFIX {q} $PATHS" --preview "$PREVIEW_COMMAND" --preview-window "$PREVIEW_WINDOW"
+} else {
+    $result=fzf --delimiter ":" --phony "$QUERYPARAM" "$INITIAL_QUERY" --ansi --cycle --bind "change:reload:powershell -m Start-Sleep .1; $RG_PREFIX {q} $PATHS" 
+}
+# Output is filename, line number, character, contents
+if ("$result".Length -lt 1) {
+    Write-Host canceled
+    "1" | Out-File -Path "$Env:CANARY_FILE"
+    exit 1
+} else {
+    if ("$SINGLE_DIR_ROOT".Length -gt 0) {
+       Join-Path -Path "$SINGLE_DIR_ROOT" -ChildPath "$result" | Out-File -Path "$Env:CANARY_FILE"        
+    } else {
+        $result | Out-File -Path "$Env:CANARY_FILE"        
+    }
+}

--- a/find_within_files.ps1
+++ b/find_within_files.ps1
@@ -1,11 +1,10 @@
 
-
 trap
 {
     # If we except, lets report it visually. Can help with debugging if there IS a problem
     # in here.
-    Write-Host "EXCEPTION: $PSItem.ToString()" -ForegroundColor Red
-    Write-Host "$PSItem.ScriptStackTrace"
+    Write-Host "EXCEPTION: $($PSItem.ToString())" -ForegroundColor Red
+    Write-Host "$($PSItem.ScriptStackTrace)"
     Start-Sleep 10
 }
 

--- a/flight_check.ps1
+++ b/flight_check.ps1
@@ -6,7 +6,7 @@ function InPath($tool) {
     Write-Host "which ${tool}: " -NoNewline
     if ((Get-Command "$tool" -ErrorAction SilentlyContinue) -eq $null) 
     { 
-        Write-Host "undefined"
+        Write-Host ""
     } else {
         Write-Host "found"
     }

--- a/flight_check.ps1
+++ b/flight_check.ps1
@@ -1,0 +1,27 @@
+
+Write-Host "Pre-Flight check:"
+Write-Host "-----------------"
+
+function InPath($tool) {
+    Write-Host "which ${tool}: " -NoNewline
+    if ((Get-Command "$tool" -ErrorAction SilentlyContinue) -eq $null) 
+    { 
+        Write-Host "undefined"
+    } else {
+        Write-Host "found"
+    }
+}
+
+Write-Host "Checking you have the required command line tools installed..." -ForegroundColor Cyan
+InPath "bat"
+InPath "fzf"
+InPath "rg"
+Write-Host "-----------------"
+
+#echo "Checking versions of the installed command line tools..."
+#echo "bat version: $(bat --version)"
+#echo "fzf version: $(fzf --version)"
+#echo "rg version: $(rg --version)"
+#echo "-----------------"
+
+echo "OK"

--- a/list_search_locations.ps1
+++ b/list_search_locations.ps1
@@ -1,0 +1,16 @@
+
+$PATHS=$args
+
+clear
+Write-Host "----------"
+Write-Host "The following files are on your search path:" -ForegroundColor Cyan
+foreach ($P in $PATHS) {
+    Write-Host "- $P"
+}
+$fc=Get-Content "$Env:EXPLAIN_FILE" -Raw
+Write-Host ""
+Write-Host "$fc"
+Write-Host "----------"
+Write-Host ""
+Write-Host "All these paths are configurable. If you\'re expecting a path but not seeing it here,"
+Write-Host "it may be turned off in the settings.\n\n"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -491,13 +491,18 @@ function doFlightCheck(): boolean {
         //vscode.window.showErrorMessage('Native Windows support does not exist at this point in time. You can however run inside a Remote-WSL workspace. See the README for more information.');
         //return false;
         // We don't flight check on windows just yet.
-        return true;
+        //return true;
     }
 
     try {
         let errStr = '';
         const kvs: any = {};
-        const out = cp.execFileSync(getCommandString(commands.flightCheck, false, false), { shell: true }).toString('utf-8');
+        let out = "";
+        if(os.platform() === 'win32') {
+            out = cp.execFileSync("powershell " + getCommandString(commands.flightCheck, false, false), { shell: true }).toString('utf-8');
+        } else {
+            out = cp.execFileSync(getCommandString(commands.flightCheck, false, false), { shell: true }).toString('utf-8');
+        }
         out.split('\n').map(x => {
             const maybeKV = parseKeyValue(x);
             if (maybeKV.length === 2) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -486,14 +486,6 @@ function doFlightCheck(): boolean {
         return line.split(': ', 2);
     };
 
-    // Windows native
-    if (os.platform() === 'win32') {
-        //vscode.window.showErrorMessage('Native Windows support does not exist at this point in time. You can however run inside a Remote-WSL workspace. See the README for more information.');
-        //return false;
-        // We don't flight check on windows just yet.
-        //return true;
-    }
-
     try {
         let errStr = '';
         const kvs: any = {};
@@ -692,7 +684,11 @@ function getCommandString(cmd: Command, withArgs: boolean = true, withTextSelect
     }
     // useTypeFilter should only be try if we activated the corresponding command
     if (CFG.useTypeFilter && CFG.findWithinFilesFilter.size > 0) {
-        ret += 'TYPE_FILTER=' + [...CFG.findWithinFilesFilter].reduce((x, y) => x + ':' + y) + ' ';
+        if(os.platform() === 'win32') {
+            ret += '$Env:TYPE_FILTER=' + "'" +[...CFG.findWithinFilesFilter].reduce((x, y) => x + ':' + y) + "'; ";
+        } else {
+            ret += 'TYPE_FILTER=' + [...CFG.findWithinFilesFilter].reduce((x, y) => x + ':' + y) + ' ';
+        }
     }
     ret += cmdPath;
     if (withArgs) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -452,7 +452,7 @@ function explainSearchLocations(useColor = false) {
 }
 
 function writePathOriginsFile() {
-    fs.writeFileSync(path.join(CFG.tempDir, 'paths_explain'), explainSearchLocations(true));
+    fs.writeFileSync(path.join(CFG.tempDir, 'paths_explain'), explainSearchLocations(os.platform() !== 'win32'));
     return true;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -565,15 +565,19 @@ function openFiles(data: string) {
     const filePaths = data.split('\n').filter(s => s !== '');
     assert(filePaths.length > 0);
     filePaths.forEach(p => {
-        // TODO: We might want to just do this the RE way on all platforms.
         let [file, lineTmp, charTmp] = p.split(':', 3);
+        // TODO: We might want to just do this the RE way on all platforms?
+        //       On Windows at least the c: makes the split approach problematic.
         if (os.platform() === 'win32') {
-            let re = /^\s*(?<file>([a-zA-Z][:])?[^:]+)(?<lineTmp>[:]\d+)?(?<charTmp>[:]\d+)?((\s*)|([:].*))$/;
+            let re = /^\s*(?<file>([a-zA-Z][:])?[^:]+)([:](?<lineTmp>\d+))?\s*([:](?<charTmp>\d+))?.*/;
             let v = p.match(re);
             if(v && v.groups) {
                 file = v.groups['file'];
                 lineTmp = v.groups['lineTmp'];
                 charTmp = v.groups['charTmp'];
+                //vscode.window.showWarningMessage('File: ' + file + "\nlineTmp: " + lineTmp + "\ncharTmp: " + charTmp);
+            } else {
+                vscode.window.showWarningMessage('Did not match anything in filename: [' + p + "] could not open file!");
             }
         }
         // On windows we sometimes get extra characters that confound


### PR DESCRIPTION
This adds a first attempt at Windows support for the find it faster plugin.
I am using *.ps1 scripts that mirror the .sh scripts.

I had to make a few changes to extension.ts but guarded those with os.platform() === 'win32' checks to attempt to ensure it did not impact mac and linux. 

I installed windows native versions of bat, fzf and ripgrep from their repos and it is working great.