### PR TITLE
fix(find_files.ps1): Fixes logic error in condition for setting $QUERYYPARAM

### DIFF
--- a/find_files.ps1
+++ b/find_files.ps1
@@ -67,7 +67,7 @@ if ($HAS_SELECTION -eq 1) {
     $QUERY=Get-Content "$SELECTION_FILE" -Raw
 }
 $QUERYPARAM=""
-if ("$QUERY".Length -gt 0) {
+if (!"$QUERY".Length -gt 0) {
     $QUERYPARAM="--query"
 }
 


### PR DESCRIPTION
The logic for setting $QUERYPARAM when $QUERY has size 0 (zero) was reversed, which I believe caused the program to open and close without showing an error message. As at https://github.com/tomrijndorp/vscode-finditfaster/issues/22