### PR TITLE
fix(windows): Incorrect `Out-File` parameters

### DIFF
--- a/find_files.ps1
+++ b/find_files.ps1
@@ -79,12 +79,12 @@ if($PREVIEW_ENABLED -eq 1) {
 # Output is filename, line number, character, contents
 if ("$result".Length -lt 1) {
     Write-Host canceled
-    "1" | Out-File -Path "$Env:CANARY_FILE"
+    "1" | Out-File -FilePath "$Env:CANARY_FILE"
     exit 1
 } else {
     if ("$SINGLE_DIR_ROOT".Length -gt 0) {
-       Join-Path -Path "$SINGLE_DIR_ROOT" -ChildPath "$result" | Out-File -Path "$Env:CANARY_FILE"        
+       Join-Path -Path "$SINGLE_DIR_ROOT" -ChildPath "$result" | Out-File -FilePath "$Env:CANARY_FILE"        
     } else {
-        $result | Out-File -Path "$Env:CANARY_FILE"        
+        $result | Out-File -FilePath "$Env:CANARY_FILE"        
     }
 }

--- a/find_within_files.ps1
+++ b/find_within_files.ps1
@@ -108,12 +108,12 @@ if($PREVIEW_ENABLED -eq 1) {
 # Output is filename, line number, character, contents
 if ("$result".Length -lt 1) {
     Write-Host canceled
-    "1" | Out-File -Path "$Env:CANARY_FILE"
+    "1" | Out-File -FilePath "$Env:CANARY_FILE"
     exit 1
 } else {
     if ("$SINGLE_DIR_ROOT".Length -gt 0) {
-       Join-Path -Path "$SINGLE_DIR_ROOT" -ChildPath "$result" | Out-File -Path "$Env:CANARY_FILE"        
+       Join-Path -Path "$SINGLE_DIR_ROOT" -ChildPath "$result" | Out-File -FilePath "$Env:CANARY_FILE"        
     } else {
-        $result | Out-File -Path "$Env:CANARY_FILE"        
+        $result | Out-File -FilePath "$Env:CANARY_FILE"        
     }
 }


### PR DESCRIPTION
In `find_files.ps1` and `find_within_files.ps1` the usage of Out-File was incorrect. It was attempting to specify the path with the `-Path` parameter, this does not exist. The correct parameter is `-FilePath`.

This should fix issue #23 

PS Docs: https://learn.microsoft.com/en-gb/previous-versions/powershell/module/microsoft.powershell.utility/out-file?view=powershell-7