### PR TITLE
Add option to slightly fuzz ripgrep query in "Find Within Files"

### DIFF
--- a/find_within_files.sh
+++ b/find_within_files.sh
@@ -40,6 +40,7 @@ PREVIEW_COMMAND=${FIND_WITHIN_FILES_PREVIEW_COMMAND:-'bat --decorations=always -
 PREVIEW_WINDOW=${FIND_WITHIN_FILES_PREVIEW_WINDOW_CONFIG:-'right:border-left:50%:+{2}+3/3:~3'}
 HAS_SELECTION=${HAS_SELECTION:-}
 RESUME_SEARCH=${RESUME_SEARCH:-}
+FUZZ_RG_QUERY=${FUZZ_RG_QUERY:-}
 # We match against the beginning of the line so everything matches but nothing gets highlighted...
 QUERY='^'
 INITIAL_QUERY=''  # Don't show initial "^" regex in fzf
@@ -88,6 +89,12 @@ RG_PREFIX_STR=$(array_join "${RG_PREFIX+"${RG_PREFIX[@]}"}")
 RG_PREFIX_STR="${RG_PREFIX+"${RG_PREFIX[@]}"}"
 FZF_CMD="${RG_PREFIX+"${RG_PREFIX[@]}"} $QUERY $(array_join "${PATHS[@]+"${PATHS[@]}"}")"
 
+RG_QUERY_PARSING="{q}"
+if [[ "$FUZZ_RG_QUERY" -eq 1 ]]; then
+    RG_QUERY_PARSING="\$(echo {q} | sed 's/ /.*/g')"
+fi
+
+
 # echo $FZF_CMD
 echo "$RG_PREFIX_STR"
 # exit 1
@@ -100,7 +107,7 @@ IFS=: read -ra VAL < <(
   FZF_DEFAULT_COMMAND="$FZF_CMD" \
   fzf --ansi \
       --cycle \
-      --bind "change:reload:sleep 0.1; $RG_PREFIX_STR {q} $(array_join "${PATHS[@]+"${PATHS[@]}"}") || true" \
+      --bind "change:reload:sleep 0.1; $RG_PREFIX_STR $RG_QUERY_PARSING $(array_join "${PATHS[@]+"${PATHS[@]}"}") || true" \
       --delimiter : \
       --history $LAST_QUERY_FILE \
       --bind "enter:execute(echo {n} > $LAST_POS_FILE)+accept" \

--- a/package.json
+++ b/package.json
@@ -193,6 +193,11 @@
           "type": "string",
           "default": ""
         },
+        "find-it-faster.findWithinFiles.fuzzRipgrepQuery": {
+          "markdownDescription": "By default, matching in \"Find Within Files\" is exact. Enabling this option relaxes the matching by slightly fuzzing the query that is sent to `rg`: it treats whitespaces as wildcards (`.*`). For example, when enabled, the query `function bar` will match `function foobar`. Otherwise, it won't. This setting does not work on Windows at the moment.",
+          "type": "boolean",
+          "default": false 
+        },
         "find-it-faster.advanced.disableStartupChecks": {
           "markdownDescription": "By default, we check that you have `fzf`, `rg`, and `bat` on your path. If you'd like to disable these checks because you're getting creative (e.g. use `cat` instead of `bat`), check this box. Obviously you may see errors on your terminal if we do call one of these programs when they are not present!",
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,6 +196,7 @@ interface Config {
     batTheme: string,
     openFileInPreviewEditor: boolean,
     killTerminalAfterUse: boolean,
+    fuzzRipgrepQuery: boolean,
 };
 const CFG: Config = {
     extensionName: undefined,
@@ -235,6 +236,7 @@ const CFG: Config = {
     batTheme: '',
     openFileInPreviewEditor: false,
     killTerminalAfterUse: false,
+    fuzzRipgrepQuery: false,
 };
 
 /** Ensure that whatever command we expose in package.json actually exists */
@@ -327,6 +329,7 @@ function updateConfigWithUserSettings() {
     CFG.findWithinFilesPreviewEnabled = getCFG('findWithinFiles.showPreview');
     CFG.findWithinFilesPreviewCommand = getCFG('findWithinFiles.previewCommand');
     CFG.findWithinFilesPreviewWindowConfig = getCFG('findWithinFiles.previewWindowConfig');
+    CFG.fuzzRipgrepQuery = getCFG('findWithinFiles.fuzzRipgrepQuery');
 }
 
 function collectSearchLocations() {
@@ -642,6 +645,7 @@ function createTerminal() {
             LAST_POS_FILE: CFG.lastPosFile,
             EXPLAIN_FILE: path.join(CFG.tempDir, 'paths_explain'),
             BAT_THEME: CFG.batTheme,
+            FUZZ_RG_QUERY: CFG.fuzzRipgrepQuery ? '1' : '0',
             /* eslint-enable @typescript-eslint/naming-convention */
         },
     });


### PR DESCRIPTION
Hey! Another minor thing that keeps bugging me :)

At the moment, searching with "Find Within Files" matches strictly (i.e., `function bar` will not match `function foobar`), whereas "Find files" matches fuzzily. The reason for this is that "Find Within Files" repeatedly calls ripgrep to load results and the matching of ripgrep is strict. This PR adds the option to slightly fuzz the query that "Find Within Files" passes to ripgrep: it replaces whitespaces with wildcards (`.*`). Thus, with the option enabled, searching for `function bar` in "Find Within Files" will also find `function foobar`. Having this option would help me (and a few friends) a lot.

The option is disabled by default.

No Windows support for now because I cannot test on Windows. 


