### PR TITLE
Add restoreFocusTerminal option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "find-it-faster",
-  "version": "0.0.25",
+  "version": "0.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "find-it-faster",
-      "version": "0.0.25",
+      "version": "0.0.28",
       "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
           "markdownDescription": "By default, if you have an active editor with a text selection, we'll use that to populate the prompt in `fzf` such that it will start filtering text directly. Uncheck to disable.",
           "type": "boolean",
           "default": true
+        },
+        "find-it-faster.general.restoreFocusTerminal": {
+          "markdownDescription": "When enabled, the extension will restore focus to the terminal after executing a command. This is useful if you frequently switch between the terminal and other parts of VS Code.",
+          "type": "boolean",
+          "default": false
         }
       }
     }


### PR DESCRIPTION
This pull request adds a new option called `restoreFocusTerminal`. For refocusing after success/fail.

Tested on MacOS, refocus works fine. With hiding things getting tricky, not working all the times, on first run there could be bug with that(can't really catch it and fix). Bug isn't crushing extention, just leave refocused terminal open.

Issue #40