### PR TITLE
Support whitespaces and fuzzing when resuming searches

### DIFF
--- a/find_within_files.sh
+++ b/find_within_files.sh
@@ -87,7 +87,7 @@ fi
 
 RG_PREFIX_STR=$(array_join "${RG_PREFIX+"${RG_PREFIX[@]}"}")
 RG_PREFIX_STR="${RG_PREFIX+"${RG_PREFIX[@]}"}"
-FZF_CMD="${RG_PREFIX+"${RG_PREFIX[@]}"} $QUERY $(array_join "${PATHS[@]+"${PATHS[@]}"}")"
+FZF_CMD="${RG_PREFIX+"${RG_PREFIX[@]}"} '$QUERY' $(array_join "${PATHS[@]+"${PATHS[@]}"}")"
 
 RG_QUERY_PARSING="{q}"
 if [[ "$FUZZ_RG_QUERY" -eq 1 ]]; then

--- a/find_within_files.sh
+++ b/find_within_files.sh
@@ -85,15 +85,15 @@ if [[ "$(printf '%s\n' "$FZF_VER_NUM" "0.36" | sort -V | head -n 1)" == "0.36" ]
     RESUME_POS_BINDING="load:pos($INITIAL_POS)"
 fi
 
-RG_PREFIX_STR=$(array_join "${RG_PREFIX+"${RG_PREFIX[@]}"}")
-RG_PREFIX_STR="${RG_PREFIX+"${RG_PREFIX[@]}"}"
-FZF_CMD="${RG_PREFIX+"${RG_PREFIX[@]}"} '$QUERY' $(array_join "${PATHS[@]+"${PATHS[@]}"}")"
-
 RG_QUERY_PARSING="{q}"
 if [[ "$FUZZ_RG_QUERY" -eq 1 ]]; then
     RG_QUERY_PARSING="\$(echo {q} | sed 's/ /.*/g')"
+    QUERY="$(echo $QUERY | sed 's/ /.*/g')"
 fi
 
+RG_PREFIX_STR=$(array_join "${RG_PREFIX+"${RG_PREFIX[@]}"}")
+RG_PREFIX_STR="${RG_PREFIX+"${RG_PREFIX[@]}"}"
+FZF_CMD="${RG_PREFIX+"${RG_PREFIX[@]}"} '$QUERY' $(array_join "${PATHS[@]+"${PATHS[@]}"}")"
 
 # echo $FZF_CMD
 echo "$RG_PREFIX_STR"


### PR DESCRIPTION
I have been using the resume search functionality very happily over the last months 🎉 Now I have finally gotten around to fixing two minor related annoyances. 

1. Resume search did not work when the resumed query contained a whitespace.
2. Fuzzing was not applied to a resumed query.

This fixes both. It works nicely in my local testing. Finally I can resume my `function bar` searches 😀

Happy holidays everyone ❄️ ☃️ 