### PR TITLE
Fix erronomous check of the unnecessary dependency `sed` for Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -503,7 +503,7 @@ function doFlightCheck(): boolean {
         if (kvs['which rg'] === undefined || kvs['which rg'] === '') {
             errStr += 'rg not found on your PATH\n. ';
         }
-        if (kvs['which sed'] === undefined || kvs['which sed'] === '') {
+        if (os.platform() !== 'win32' && (kvs['which sed'] === undefined || kvs['which sed'] === '')) {
             errStr += 'sed not found on your PATH\n. ';
         }
         if (errStr !== '') {


### PR DESCRIPTION
On Windows, the error `sed not found on your PATH` occurs because `flight_check.ps1` doesn't produce `which sed` and `doFlightCheck()` in `extension.ts` requires it. To resolve this, I change `doFlightCheck()` to require `which sed` only when if it is not on Windows.