### PR TITLE
change `decodeURI()` to `decodeURIComponent()` to fix encoding specia…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -393,7 +393,7 @@ function collectSearchLocations() {
     // add the workspace folders
     if (CFG.searchWorkspaceFolders && vscode.workspace.workspaceFolders !== undefined) {
         const dirs = vscode.workspace.workspaceFolders.map(x => {
-            const uri = decodeURI(x.uri.toString());
+            const uri = decodeURIComponent(x.uri.toString());
             if (uri.substring(0, 7) === 'file://') {
                 if(os.platform() === 'win32') {
                     return uri.substring(8)


### PR DESCRIPTION
This pull request fixes following issue:

- #51 

It changes `decodeURI` function to `decodeURIComponent` to prevent encoding special chars in the string of current working directory such as "(@ & = + $)"