### PR TITLE
Reset env var for has selection on windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -719,6 +719,10 @@ function getCommandString(cmd: Command, withArgs: boolean = true, withTextSelect
                 } else {
                     ret += 'HAS_SELECTION=1 ';
                 }
+            } else {
+                if (os.platform() === 'win32') {
+                    ret += '$Env:HAS_SELECTION=0; ';
+                }
             }
         }
     }


### PR DESCRIPTION
Because we have to set enviromental vars on windows, they stay even after execution.
This PR aims to at least reset the selection env var, which hinders productivity