### PR TITLE
Provide option to set shell path, allowing use of non default terminal for extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "find-it-faster",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "find-it-faster",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,11 @@
           "markdownDescription": "When enabled, the extension will create the terminal in the main editor stage.",
           "type": "boolean",
           "default": false
+        },
+        "find-it-faster.general.shellPathForTerminal": {
+          "markdownDescription": "Set the path for the shell (terminal type) to be used.",
+          "type": "string",
+          "default": ""
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -697,6 +697,7 @@ function createTerminal() {
             /* eslint-enable @typescript-eslint/naming-convention */
         },
     };
+    // Use provided terminal from settings, otherwise use default terminal profile
     if (CFG.shellPathForTerminal !== '') {
         terminalOptions.shellPath = CFG.shellPathForTerminal;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,6 +202,7 @@ interface Config {
     fuzzRipgrepQuery: boolean,
     restoreFocusTerminal: boolean,
     useTerminalInEditor: boolean,
+    shellPathForTerminal: string,
 };
 const CFG: Config = {
     extensionName: undefined,
@@ -244,6 +245,7 @@ const CFG: Config = {
     fuzzRipgrepQuery: false,
     restoreFocusTerminal: false,
     useTerminalInEditor: false,
+    shellPathForTerminal: '',
 };
 
 /** Ensure that whatever command we expose in package.json actually exists */
@@ -339,6 +341,7 @@ function updateConfigWithUserSettings() {
     CFG.fuzzRipgrepQuery = getCFG('findWithinFiles.fuzzRipgrepQuery');
     CFG.restoreFocusTerminal = getCFG('general.restoreFocusTerminal');
     CFG.useTerminalInEditor = getCFG('general.useTerminalInEditor');
+    CFG.shellPathForTerminal = getCFG('general.shellPathForTerminal');
 }
 
 function collectSearchLocations() {
@@ -666,7 +669,7 @@ function handleTerminalFocusRestore(commandWasSuccess: boolean) {
 }
 
 function createTerminal() {
-    term = vscode.window.createTerminal({
+    const terminalOptions: vscode.TerminalOptions = {
         name: 'F️indItFaster',
         location: CFG.useTerminalInEditor ? vscode.TerminalLocation.Editor : vscode.TerminalLocation.Panel,
         hideFromUser: !CFG.useTerminalInEditor, // works only for terminal panel, not editor stage
@@ -693,7 +696,12 @@ function createTerminal() {
             FUZZ_RG_QUERY: CFG.fuzzRipgrepQuery ? '1' : '0',
             /* eslint-enable @typescript-eslint/naming-convention */
         },
-    });
+    };
+    if (CFG.shellPathForTerminal !== '') {
+        terminalOptions.shellPath = CFG.shellPathForTerminal;
+    }
+
+    term = vscode.window.createTerminal(terminalOptions);
 }
 
 function getWorkspaceFoldersAsString() {


### PR DESCRIPTION
This came from a desire to use powershell on windows for this extension but not have it be my default terminal.

Adds a setting to the extension to provide a path to the desired shell. In the code if this setting !== '', then it will use the path provided, otherwise defaulting to the vscode default terminal.

Apologies if anything is missing from this PR - happy to try and polish it up if needed.

![image](https://github.com/user-attachments/assets/f12ef62c-eeb9-4c78-b840-c91bff64e597)
