### PR TITLE
Fix: wrong env names in find_files.ps1

### DIFF
--- a/find_files.ps1
+++ b/find_files.ps1
@@ -58,9 +58,9 @@ if ($PATHS.Count -eq 1) {
     $PATHS=""
 }
 
-$PREVIEW_ENABLED=VGet "env:FIND_WITHIN_FILES_PREVIEW_ENABLED" 0
-$PREVIEW_COMMAND=VGet "env:FIND_WITHIN_FILES_PREVIEW_COMMAND"  'bat --decorations=always --color=always --plain {}'
-$PREVIEW_WINDOW=VGet "env:FIND_WITHIN_FILES_PREVIEW_WINDOW_CONFIG" 'right:50%:border-left'
+$PREVIEW_ENABLED=VGet "env:FIND_FILES_PREVIEW_ENABLED" 0
+$PREVIEW_COMMAND=VGet "env:FIND_FILES_PREVIEW_COMMAND"  'bat --decorations=always --color=always --plain {}'
+$PREVIEW_WINDOW=VGet "env:FIND_FILES_PREVIEW_WINDOW_CONFIG" 'right:50%:border-left'
 $HAS_SELECTION=VGet "env:HAS_SELECTION" 0
 $SELECTION_FILE=VGet "env:SELECTION_FILE" ""
 $QUERY=""


### PR DESCRIPTION
## Description

The env variable names are wrong in `find_files.ps1`, should use `FIND_FILES_*` instead of `FIND_WITHIN_FILES_*`