### PR TITLE
Add option to change shell argument for vscode-finditfaster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "find-it-faster",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "find-it-faster",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,11 @@
           "markdownDescription": "Set the path for the shell (terminal type) to be used.",
           "type": "string",
           "default": ""
+        },
+        "find-it-faster.general.shellArgsForTerminal": {
+          "markdownDescription": "Set the args for the shell (terminal type) to be used.",
+          "type": "array | undefined",
+          "default": "undefined"
         }
       }
     }


### PR DESCRIPTION
For #65, I'm using a setting like:


```
    "terminal.integrated.profiles.linux": {
        "tmux": {
            "path": "zsh",
            "args": [
                "-c",
                "tmux attach -d -t vscode_${workspaceFolder} || tmux new -s vscode_${workspaceFolder} "
            ]
        }
    },
```

But this doesn't work well with finditfaster. Now, I can override those defaults via something like:

```
    "find-it-faster.general.shellPathForTerminal": "/usr/bin/sh",
    "find-it-faster.general.shellArgsForTerminal": [] // <- this is the introduced option in this PR.
```

My VSCode also autoformatted extension.ts, hope that's not a problem.